### PR TITLE
ldtk_rust 0.4.0 (ldtk 0.8.1) support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bevy-unstable = []
 
 [dependencies]
 bevy = "0.4"
-ldtk = "0.2"
+ldtk = { package = "ldtk_rust", git = "https://github.com/estivate/ldtk_rust" }
 anyhow = "1.0.37"
 serde_json = "1.0.61"
 thiserror = "1.0.23"

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -65,28 +65,25 @@ async fn load_ldtk<'a, 'b>(
     // Create our dependency list
     let mut dependencies = Vec::new();
 
-    // Loop through the definitions in the project
-    for def in &map.project.defs {
-        // Loop through the tilesets
-        for tileset in &def.tilesets {
-            // Get the path to the tileset image asset
-            let file_path = load_context
-                .path()
-                .parent()
-                .unwrap()
-                .join(&tileset.rel_path);
-            let asset_path = AssetPath::new(file_path.clone(), None);
+    // Loop through the tilesets
+    for tileset in &map.project.defs.tilesets {
+        // Get the path to the tileset image asset
+        let file_path = load_context
+            .path()
+            .parent()
+            .unwrap()
+            .join(&tileset.rel_path);
+        let asset_path = AssetPath::new(file_path.clone(), None);
 
-            // Add asset to our dependencies list to make sure it is loaded by the asset
-            // server when our map is.
-            dependencies.push(asset_path.clone());
+        // Add asset to our dependencies list to make sure it is loaded by the asset
+        // server when our map is.
+        dependencies.push(asset_path.clone());
 
-            // Obtain a handle to the tileset image asset
-            let handle: Handle<Texture> = load_context.get_handle(asset_path.clone());
+        // Obtain a handle to the tileset image asset
+        let handle: Handle<Texture> = load_context.get_handle(asset_path.clone());
 
-            // Add the tileset handle to the map asset
-            map.tile_sets.insert(tileset.identifier.clone(), handle);
-        }
+        // Add the tileset handle to the map asset
+        map.tile_sets.insert(tileset.identifier.clone(), handle);
     }
 
     // Set the loaded map as the default asset for this file

--- a/src/system.rs
+++ b/src/system.rs
@@ -91,9 +91,8 @@ fn process_ldtk_maps(
                 // Get the tileset info
                 let tileset_info = project
                     .defs
+                    .tilesets
                     .iter()
-                    .map(|x| &x.tilesets)
-                    .flatten()
                     .filter(|x| &x.identifier == tileset_name)
                     .next()
                     .expect("Could not find tilset inside of map data");
@@ -111,8 +110,6 @@ fn process_ldtk_maps(
                     Color::hex(
                         level
                             .bg_color
-                            .as_ref()
-                            .unwrap_or(&map.project.default_level_bg_color)
                             .strip_prefix("#")
                             .expect("Invalid background color"),
                     )
@@ -130,7 +127,7 @@ fn process_ldtk_maps(
                 .enumerate()
             {
                 // Get the information for the tileset associated to this layer
-                let (tileset_info, tileset_texture) = if let Some(uid) = layer.__tileset_def_uid {
+                let (tileset_info, tileset_texture) = if let Some(uid) = layer.tileset_def_uid {
                     tilesets.get(&uid).expect("Missing tileset").clone()
 
                 // Skip this layer if there is no tileset texture for it
@@ -170,7 +167,7 @@ fn process_ldtk_maps(
                         ),
                         LdtkTilemapTileInfo {
                             tile_index: tileset_tile_y * tileset_width_tiles + tileset_tile_x,
-                            flip_bits: if tile.f.x { 1 } else { 0 } | if tile.f.y { 2 } else { 0 },
+                            flip_bits: tile.f as u32,
                         },
                     );
                 }
@@ -178,8 +175,8 @@ fn process_ldtk_maps(
                 // Go through our tiles HashMap and convert it to a 1D vector of all of the tiles'
                 // information.
                 let mut tiles = Vec::new();
-                for y in 0..layer.__c_hei as u32 {
-                    for x in (0..layer.__c_wid as u32).rev() {
+                for y in 0..layer.c_hei as u32 {
+                    for x in (0..layer.c_wid as u32).rev() {
                         tiles.push(tiles_map.get(&(x, y)).map(Clone::clone).unwrap_or(
                             LdtkTilemapTileInfo {
                                 flip_bits: 0,


### PR DESCRIPTION
Hello.

I'm new to the ldtk & bevy world, but i noticed that i couldn't parse maps created with ldtk 0.8.1 so i made some patches in order to make it work. There isn't an official release of ldtk_rust 0.4.0, but there is a tag on their github and master supports 0.8.1, so i am using that for now.

I see there is some issue with the "both flip", but i'm not sure if/how it worked before so maybe you can hint. Colors seem to be weird as well, although i'm not sure if this is a problem with my patch or me not setting a proper background with bevy?

See rendered in bevy:
![image](https://user-images.githubusercontent.com/3235069/110542312-2dfb0580-8129-11eb-92c0-5ec73cb49fd7.png)

Versus in ldtk:
![image](https://user-images.githubusercontent.com/3235069/110542388-4408c600-8129-11eb-94fd-eaffc7a39d9f.png)


Maybe this will be useful once it is actually released, if not feel free to close!

Thanks!